### PR TITLE
MNT: Use hash for Action workflow versions and update, and add dependabot, if needed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: ".github/workflows" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
         with:
           activate-environment: grism_overlap-${{ matrix.python-version }}
 


### PR DESCRIPTION
As recommended by https://scientific-python.org/specs/spec-0008/#pin-github-actions-release-workflows-to-their-full-release-commit-shas , this PR changes your Actions workflow version pins to hashes, and updates to latest release hashes (at the time of writing) if needed. Also adds a dependabot.yml file to enable future automatic updates of GitHub Actions workflow(s) in this repository, if needed.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/60)